### PR TITLE
Compile assets on postinstall in production environments

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -5,7 +5,7 @@
   "description": "<%= projectDesc %>",
   "keywords": [],
   "scripts": {
-    "postinstall": "bower install",
+    "postinstall": "$(npm bin)/bower install && [[ $NODE_ENV = 'production' ]] && $(npm bin)/gulp",
     "start": "$(npm bin)/gulp serve",
     "test": "mocha"
   },


### PR DESCRIPTION
We need to run gulp to get things to work on heroku, and we're currently
using the fact that it sets NODE_ENV to determine that we're on heroku.

Closes #18.
